### PR TITLE
Enable use with `python -m` or `pythonw -m`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ Note:
 Usage
 -----
 
-A program is provided available as ``Scripts/pyqt6-tools.exe``.  There are
-subcommands provided for each of Designer, QML Scene, and the QML Test Runner.
+A program is provided available as ``Scripts/pyqt6-tools.exe`` or ``python -m pyqt6_tools``.
+There are subcommands provided for each of Designer, QML Scene, and the QML Test Runner.
 These wrapper commands provide additional functionality related to launching
 the underlying programs.  A larger set of Qt application are available as
 subcommands of the ``Scripts/qt6-tools.exe`` program.  In both cases, passing

--- a/README.rst
+++ b/README.rst
@@ -64,8 +64,8 @@ Note:
 Usage
 -----
 
-A program is provided available as ``Scripts/pyqt6-tools.exe`` or ``python -m pyqt6_tools``.
-There are subcommands provided for each of Designer, QML Scene, and the QML Test Runner.
+A program is provided available as ``Scripts/pyqt6-tools.exe``.  There are
+subcommands provided for each of Designer, QML Scene, and the QML Test Runner.
 These wrapper commands provide additional functionality related to launching
 the underlying programs.  A larger set of Qt application are available as
 subcommands of the ``Scripts/qt6-tools.exe`` program.  In both cases, passing
@@ -80,6 +80,12 @@ working directory to find a ``.env`` file and loads it if found.  If found, the
 environment variable ``DOT_ENV_DIRECTORY`` will be set to the directory
 containing the ``.env`` file.  With this extra variable you can specify paths
 relative to the ``.env`` location.
+
+There alternative ways to call ``Scripts/pyqt6-tools.exe``, ``python -m pyqt6_tools``
+works the same way but allows you to choose the version of python to run the tools
+with. On Windows if you create a shortcut to `pyqt6-tools.exe`, it will show a
+command prompt that stays open for the duration of the launched application. You
+can address this by using ``Scripts/pyqt6-toolsw.exe`` or ``pythonw -m pyqt6_tools``.
 
 .. code-block:: powershell
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ if pyqt_major_version == '5':
         ["Qt6", "Qt5"],
         ["Qt6", "Qt 5"],
         ["6.4", "5.15"],
+        ["pyuic6", "pyuic5"],
     ]
     for a, b in replacements:
         readme = readme.replace(a, b)
@@ -108,6 +109,9 @@ setuptools.setup(
     entry_points={
         'console_scripts': [
             'pyqt{major}-tools = pyqt{major}_tools.entrypoints:main'.format(major=pyqt_major_version),
+        ],
+        'gui_scripts': [
+            'pyqt{major}-toolsw = pyqt{major}_tools.entrypoints:main'.format(major=pyqt_major_version),
         ]
     }
 )

--- a/src/pyqt_tools/__main__.py
+++ b/src/pyqt_tools/__main__.py
@@ -1,19 +1,12 @@
-""" Enables support for calling entrypoints using `python -m` or `pythonw -m`.
-On windows using `pythonw -m pyqt6_tools designer` in a shortcut allows opening
-QtDesigner without showing a command prompt window that stays open the entire
-time that QtDesigner is open.
+""" Enables support for calling entrypoints using `python -m`.
+
+Examples:
+    Launching PyQt6 designer: `python -m pyqt6_tools designer`
+    Launching PyQt5 designer: `python -m pyqt5_tools designer`
 """
 
 
-import importlib
-import pathlib
 import sys
+from . import entrypoints
 
-if __name__ == "__main__":
-    # Relative imports don't work when called by `python -m ...`, get the name
-    # of the parent folder so we can import entrypoints from it. This is needed
-    # because the package name is not hard coded between PyQt versions.
-    module_name = pathlib.Path(__file__).parent.stem
-    entrypoints = importlib.import_module(f"{module_name}.entrypoints")
-
-    sys.exit(entrypoints.main())
+sys.exit(entrypoints.main())

--- a/src/pyqt_tools/__main__.py
+++ b/src/pyqt_tools/__main__.py
@@ -1,0 +1,19 @@
+""" Enables support for calling entrypoints using `python -m` or `pythonw -m`.
+On windows using `pythonw -m pyqt6_tools designer` in a shortcut allows opening
+QtDesigner without showing a command prompt window that stays open the entire
+time that QtDesigner is open.
+"""
+
+
+import importlib
+import pathlib
+import sys
+
+if __name__ == "__main__":
+    # Relative imports don't work when called by `python -m ...`, get the name
+    # of the parent folder so we can import entrypoints from it. This is needed
+    # because the package name is not hard coded between PyQt versions.
+    module_name = pathlib.Path(__file__).parent.stem
+    entrypoints = importlib.import_module(f"{module_name}.entrypoints")
+
+    sys.exit(entrypoints.main())

--- a/src/pyqt_tools/tests/test_entrypoints.py
+++ b/src/pyqt_tools/tests/test_entrypoints.py
@@ -23,7 +23,15 @@ _import_it('pyqt_plugins', 'utilities')
 fspath = getattr(os, 'fspath', str)
 
 scripts_path = pathlib.Path(sysconfig.get_path("scripts"))
-executable_path_string = fspath(scripts_path.joinpath("pyqt{}-tools".format(major)))
+# Use parametrize to test each method for launching pyqt-tools in a subprocess
+executable_paths = (
+    "executable_cmd",
+    [
+        [fspath(scripts_path.joinpath("pyqt{}-tools".format(major)))],
+        [fspath(scripts_path.joinpath("pyqt{}-toolsw".format(major)))],
+        [sys.executable, "-m", "pyqt{}_tools".format(major)],
+    ]
+)
 
 vars_to_print = [
     *pyqt_plugins.utilities.diagnostic_variables_to_print,
@@ -41,7 +49,8 @@ def environment_fixture():
     return environment
 
 
-def test_designer_creates_test_widget(tmp_path, environment):
+@pytest.mark.parametrize(*executable_paths)
+def test_designer_creates_test_widget(tmp_path, environment, executable_cmd):
     file_path = tmp_path/'tigger'
     environment[pyqt_plugins.tests.testbutton.test_path_env_var] = fspath(file_path)
 
@@ -60,10 +69,7 @@ def test_designer_creates_test_widget(tmp_path, environment):
 
     with pytest.raises(subprocess.TimeoutExpired):
         subprocess.run(
-            [
-                executable_path_string,
-                'designer',
-            ],
+            executable_cmd + ['designer'],
             check=True,
             env=environment,
             timeout=40,
@@ -127,7 +133,8 @@ def test_qmlscene_paints_test_item(tmp_path, environment):
     reason="accepting failure until we figure out the problem".format(string_version),
     strict=True,
 )
-def test_qmltestrunner_paints_test_item(tmp_path, environment):
+@pytest.mark.parametrize(*executable_paths)
+def test_qmltestrunner_paints_test_item(tmp_path, environment, executable_cmd):
     file_path = tmp_path/'piglet'
     environment[pyqt_plugins.examples.exampleqmlitem.test_path_env_var] = fspath(file_path)
 
@@ -138,8 +145,7 @@ def test_qmltestrunner_paints_test_item(tmp_path, environment):
     pyqt_plugins.utilities.print_environment_variables(environment, *vars_to_print)
 
     subprocess.run(
-        [
-            executable_path_string,
+        executable_cmd + [
             'qmltestrunner',
             '--',
             '-input',
@@ -156,14 +162,12 @@ def test_qmltestrunner_paints_test_item(tmp_path, environment):
     )
 
 
-def test_installuic_does_not_fail(environment):
+@pytest.mark.parametrize(*executable_paths)
+def test_installuic_does_not_fail(environment, executable_cmd):
     pyqt_plugins.utilities.print_environment_variables(environment, *vars_to_print)
 
     subprocess.run(
-        [
-            executable_path_string,
-            'installuic',
-        ],
+        executable_cmd + ['installuic'],
         check=True,
         env=environment,
         timeout=40,


### PR DESCRIPTION
Add support for `python -m pyqt6_tools`. The ultimate goal is to on windows be able to create a desktop shortcut that opens QtDesigner without showing a command prompt that has to stay open for the duration that designer is running. This is accomplished by launching using `pythonw.exe` instead of `python.exe` instead of the console_scripts entry_point.

An alternative way to accomplish this could be to add a second `gui_scripts` exe to setup.py. This ends up adding a second executable, I'm not sure if this is desirable.
setup.py:
```py
    entry_points={
        'console_scripts': [
            'pyqt{major}-tools = pyqt{major}_tools.entrypoints:main'.format(major=pyqt_major_version),
        ],
        'gui_scripts': [
            'pyqt{major}-toolsw = pyqt{major}_tools.entrypoints:main'.format(major=pyqt_major_version),
        ]
    }
```

Also, I'm still needing to support PyQt5 so I would want to make sure this is added to the pyqt5-tools releases as well.